### PR TITLE
Fix help page specs

### DIFF
--- a/lib/rfc_reader/terminal.rb
+++ b/lib/rfc_reader/terminal.rb
@@ -12,9 +12,15 @@ module RfcReader
     # @param choices [Array<String>] where all choices are unique
     def self.choose(prompt, choices)
       require "tty-prompt"
-      TTY::Prompt.new.select(prompt, choices)
-    rescue TTY::Reader::InputInterrupt
-      exit # We want people to be able to control-C out of this prompt.
+      TTY::Prompt
+        .new(
+          quiet: true,
+          track_history: false,
+          interrupt: :exit,
+          symbols: { marker: ">" },
+          enable_color: !ENV["NO_COLOR"]
+        )
+        .select(prompt, choices)
     end
   end
 end

--- a/spec/fixtures/snapshots/command-help-library.snap
+++ b/spec/fixtures/snapshots/command-help-library.snap
@@ -4,4 +4,5 @@ Usage:
 Description:
   List the last 100 RFCs that have already been downloaded.
 
-  Choose any RFC from the list that seems interesting and you can read it offline in your terminal.
+  Choose any RFC from the list that seems interesting and you can read it
+  offline in your terminal.

--- a/spec/fixtures/snapshots/command-help-library.snap
+++ b/spec/fixtures/snapshots/command-help-library.snap
@@ -1,5 +1,5 @@
 Usage:
-  rspec library
+  rfc-reader library
 
 Description:
   List the last 100 RFCs that have already been downloaded.

--- a/spec/fixtures/snapshots/command-help-recent.snap
+++ b/spec/fixtures/snapshots/command-help-recent.snap
@@ -4,4 +4,5 @@ Usage:
 Description:
   Fetch the most recent 15 RFCs on rfc-editor.org and list them.
 
-  Choose any RFC from the list that seems interesting and it will get downloaded so that you can read it in your terminal.
+  Choose any RFC from the list that seems interesting and it will get
+  downloaded so that you can read it in your terminal.

--- a/spec/fixtures/snapshots/command-help-recent.snap
+++ b/spec/fixtures/snapshots/command-help-recent.snap
@@ -1,5 +1,5 @@
 Usage:
-  rspec recent
+  rfc-reader recent
 
 Description:
   Fetch the most recent 15 RFCs on rfc-editor.org and list them.

--- a/spec/fixtures/snapshots/command-help-search.snap
+++ b/spec/fixtures/snapshots/command-help-search.snap
@@ -4,4 +4,5 @@ Usage:
 Description:
   Search for RFCs on rfc-editor.org by the given term and list them.
 
-  Choose any RFC from the list that seems interesting and it will get downloaded so that you can read it in your terminal.
+  Choose any RFC from the list that seems interesting and it will get
+  downloaded so that you can read it in your terminal.

--- a/spec/fixtures/snapshots/command-help-search.snap
+++ b/spec/fixtures/snapshots/command-help-search.snap
@@ -1,5 +1,5 @@
 Usage:
-  rspec search [TERM]
+  rfc-reader search [TERM]
 
 Description:
   Search for RFCs on rfc-editor.org by the given term and list them.

--- a/spec/fixtures/snapshots/command-help.snap
+++ b/spec/fixtures/snapshots/command-help.snap
@@ -7,9 +7,9 @@ The last 100 downloaded RFCs are saved locally so that they can be
 read later on without the need for an internet connection.
 
 Commands:
-  rspec help [COMMAND]  # Describe available commands or one specific command
-  rspec library         # List already downloaded RFCs for reading
-  rspec recent          # List recent RFC releases for reading
-  rspec search [TERM]   # Search for RFCs by TERM for reading
-  rspec version         # Print the program version
+  rfc-reader help [COMMAND]  # Describe available commands or one specific command
+  rfc-reader library         # List already downloaded RFCs for reading
+  rfc-reader recent          # List recent RFC releases for reading
+  rfc-reader search [TERM]   # Search for RFCs by TERM for reading
+  rfc-reader version         # Print the program version
 

--- a/spec/fixtures/snapshots/online-search.snap
+++ b/spec/fixtures/snapshots/online-search.snap
@@ -1,7 +1,6 @@
-[?25lChoose an RFC to read: [90m(Press ↑/↓ arrow to move and Enter to select)[0m
-[32m‣ Common Format and MIME Type for Comma-Separated Values (CSV) Files[0m[2K[1G[1A[2K[1GChoose an RFC to read: 
-[32m‣ Common Format and MIME Type for Comma-Separated Values (CSV) Files[0m[2K[1G[1A[2K[1GChoose an RFC to read: [32mCommon Format and MIME Type for Comma-Separated Values (CSV) Files[0m
-[?25h
+[?25lChoose an RFC to read: (Press ↑/↓ arrow to move and Enter to select)
+> Common Format and MIME Type for Comma-Separated Values (CSV) Files[2K[1G[1A[2K[1GChoose an RFC to read: 
+> Common Format and MIME Type for Comma-Separated Values (CSV) Files[2K[1G[1A[2K[1G[?25h
 
 
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -23,14 +23,35 @@ RSpec.describe "integration tests" do
     it "returns the expected result" do
       Open3.popen2(exe_path, "recent") do |input, output|
         input.puts enter_key
-        result = output.read
-
-        expect(result)
+        expect(output.read)
           .to include("Request for Comments:")
           .and include("Status of This Memo")
           .and include("Copyright Notice")
           .and include("Table of Contents")
           .and include("1.  Introduction")
+      end
+    end
+  end
+
+  describe "help" do
+    it "returns the default help page", :aggregate_failures do
+      Open3.popen2(exe_path) do |_input, output|
+        expect(output.read).to match_snapshot("command-help")
+      end
+      Open3.popen2(exe_path, "help") do |_input, output|
+        expect(output.read).to match_snapshot("command-help")
+      end
+    end
+
+    it "shows the subcommand help page", :aggregate_failures do
+      Open3.popen2(exe_path, "help", "recent") do |_input, output|
+        expect(output.read).to match_snapshot("command-help-recent")
+      end
+      Open3.popen2(exe_path, "help", "library") do |_input, output|
+        expect(output.read).to match_snapshot("command-help-library")
+      end
+      Open3.popen2(exe_path, "help", "search") do |_input, output|
+        expect(output.read).to match_snapshot("command-help-search")
       end
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "integration tests" do
 
   describe "search", :online do
     it "returns the expected result" do
-      Open3.popen2(exe_path, "search", "4180") do |input, output|
+      Open3.popen2({ "NO_COLOR" => "1" }, exe_path, "search", "4180") do |input, output|
         input.puts enter_key
         expect(output.read).to match_snapshot("online-search")
       end
@@ -21,7 +21,7 @@ RSpec.describe "integration tests" do
 
   describe "recent", :online do
     it "returns the expected result" do
-      Open3.popen2(exe_path, "recent") do |input, output|
+      Open3.popen2({ "NO_COLOR" => "1" }, exe_path, "recent") do |input, output|
         input.puts enter_key
         expect(output.read)
           .to include("Request for Comments:")

--- a/spec/lib/rfc_reader/command_spec.rb
+++ b/spec/lib/rfc_reader/command_spec.rb
@@ -2,6 +2,15 @@
 
 RSpec.describe RfcReader::Command do
   describe "#help" do
+    # Prevent the `rspec` program name from being used in tests.
+    around do |example|
+      old_program_name = $PROGRAM_NAME
+      $PROGRAM_NAME = "rfc-reader"
+      example.run
+    ensure
+      $PROGRAM_NAME = old_program_name if old_program_name
+    end
+
     it "matches default command usage" do
       expect { described_class.start }
         .to output(snapshot("command-help")).to_stdout

--- a/spec/lib/rfc_reader/command_spec.rb
+++ b/spec/lib/rfc_reader/command_spec.rb
@@ -1,37 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RfcReader::Command do
-  describe "#help" do
-    # Prevent the `rspec` program name from being used in tests.
-    around do |example|
-      old_program_name = $PROGRAM_NAME
-      $PROGRAM_NAME = "rfc-reader"
-      example.run
-    ensure
-      $PROGRAM_NAME = old_program_name if old_program_name
-    end
-
-    it "matches default command usage" do
-      expect { described_class.start }
-        .to output(snapshot("command-help")).to_stdout
-        .and not_to_output.to_stderr
-    end
-
-    it "matches default command help" do
-      expect { described_class.start(%w[help]) }
-        .to output(snapshot("command-help")).to_stdout
-        .and not_to_output.to_stderr
-    end
-
-    it "matches command specific help pages", :aggregate_failures do
-      %w[library recent search].each do |subcommand|
-        expect { described_class.start(["help", subcommand]) }
-          .to output(snapshot("command-help-#{subcommand}")).to_stdout
-          .and not_to_output.to_stderr
-      end
-    end
-  end
-
   describe "#recent", :setup_xdg_dirs do
     let(:title) { "RFC 9605: Secure Frame (SFrame): Lightweight Authenticated Encryption for Real-Time Media" }
 


### PR DESCRIPTION
These were failing for a few reasons but the main one was that the dumb terminal couldn't figure out the program name in specs (it assumed it was `rspec`) and the interactive choose one prompt was too complex for tests (too many colors and unicode characters). I simplified both these by using more integration tests and simplifying the prompt.