### PR TITLE
Improve error messages

### DIFF
--- a/exe/rfc-reader
+++ b/exe/rfc-reader
@@ -4,4 +4,4 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "rfc_reader"
 
-exit RfcReader::Command.start
+exit RfcReader.start

--- a/lib/rfc_reader.rb
+++ b/lib/rfc_reader.rb
@@ -8,4 +8,12 @@ module RfcReader
   autoload :Search, "rfc_reader/search"
   autoload :Terminal, "rfc_reader/terminal"
   autoload :Library, "rfc_reader/library"
+  autoload :ErrorContext, "rfc_reader/error_context"
+
+  # @return [Integer] exit code
+  def self.start
+    ErrorContext.handler do
+      Command.start
+    end
+  end
 end

--- a/lib/rfc_reader/error_context.rb
+++ b/lib/rfc_reader/error_context.rb
@@ -25,8 +25,10 @@ module RfcReader
 
       def full_message
         <<~MESSAGE
-          Context: #{@context}
-          Error: #{@cause.class}
+          Context:
+          #{indent(@context)}
+          Error:
+             #{@cause.class}
           Message:
           #{indent(message)}
           Backtrace:

--- a/lib/rfc_reader/error_context.rb
+++ b/lib/rfc_reader/error_context.rb
@@ -13,9 +13,9 @@ module RfcReader
 
       # @param cause [StandardError]
       # @param context [String] (Optional)
-      def initialize(cause:, context: default_context)
+      def initialize(cause:, context: nil)
         @cause = cause
-        @context = context
+        @context = context || default_context
         super
       end
 
@@ -25,19 +25,31 @@ module RfcReader
 
       def full_message
         <<~MESSAGE
-          Context: #{context}
-          Error: #{cause.class}
+          Context: #{@context}
+          Error: #{@cause.class}
           Message:
-          #{message}
+          #{indent(message)}
           Backtrace:
-          #{bracktrace}
+          #{indent(backtrace)}
         MESSAGE
       end
 
       private
 
       def default_context
-        "#{cause.class}: #{message.lines.first}"
+        "#{@cause.class}: #{message.lines.first}"
+      end
+
+      def indent(string_or_array)
+        strings = case string_or_array
+                  when Array then string_or_array
+                  when String then string_or_array.lines
+                  else raise ArgumentError, "Expected string or array instead of #{string_or_array.class}"
+                  end
+
+        strings
+          .map { _1.prepend("   ") }
+          .join("\n")
       end
     end
 

--- a/lib/rfc_reader/error_context.rb
+++ b/lib/rfc_reader/error_context.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module RfcReader
+  module ErrorContext
+    class ContextError < StandardError
+      extend Forwardable
+
+      attr_reader :context
+
+      def_delegators :@cause, :message, :to_s, :backtrace, :backtrace_locations
+
+      # @param cause [StandardError]
+      # @param context [String] (Optional)
+      def initialize(cause:, context: default_context)
+        @cause = cause
+        @context = context
+        super
+      end
+
+      def short_message
+        "Error: #{context}"
+      end
+
+      def full_message
+        <<~MESSAGE
+          Context: #{context}
+          Error: #{cause.class}
+          Message:
+          #{message}
+          Backtrace:
+          #{bracktrace}
+        MESSAGE
+      end
+
+      private
+
+      def default_context
+        "#{cause.class}: #{message.lines.first}"
+      end
+    end
+
+    # Yields an error context. Any `StandardError` that gets raised in this block
+    # gets wrapped by `ContextError` automatically and re-raised.
+    #
+    # If no error has been raised, it returns the result of the block.
+    #
+    # @param context [String]
+    # @return yielded block value
+    def self.wrap(context)
+      yield
+    rescue StandardError => e
+      raise ContextError.new(cause: e, context: context)
+    end
+
+    # Yields a handler context where any `StandardError` is caught and the error message is
+    # printed to stderr along with the context. It prints only a short message by default
+    # and prints the full error message if the `DEBUG` error message is set. It then exits
+    # with a non-zero error code.
+    #
+    # If no error has been raised, it returns the result of the block as an integer.
+    # If the result of block cannot be turned into an integer, it returns zero.
+    #
+    # @return [Integer] exit code
+    def self.handler
+      error = nil
+
+      begin
+        result = yield
+        return result.respond_to?(:to_i) ? result.to_i : 0
+      rescue ContextError => e
+        error = e
+      rescue StandardError => e
+        error = ContextError.new(cause: e)
+      end
+
+      if ENV["DEBUG"]
+        warn error.full_message
+      else
+        warn error.short_message
+        warn "Note: Set the `DEBUG` environment variable to see the full error context"
+      end
+
+      1
+    end
+  end
+end

--- a/lib/rfc_reader/library.rb
+++ b/lib/rfc_reader/library.rb
@@ -16,7 +16,10 @@ module RfcReader
       file_name = File.basename(url)
       file_path = File.join(library_cache_dir, file_name)
 
-      content = Net::HTTP.get(URI(url))
+      content = ErrorContext.wrap("Downloading RFC document") do
+        Net::HTTP.get(URI(url))
+      end
+
       FileUtils.mkdir_p(library_cache_dir)
       File.write(file_path, content)
       add_to_catalog(title: title, url: url, path: file_path)

--- a/spec/lib/rfc_reader/command_spec.rb
+++ b/spec/lib/rfc_reader/command_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RfcReader::Command do
       VCR.use_cassette("command-recent") do
         expect { described_class.start(%w[recent]) }
           .to output(snapshot("rfc-9605")).to_stdout
-          .and not_to_output.to_stderr
+          .and not_output.to_stderr
       end
 
       catalog = RfcReader::Library.catalog
@@ -45,7 +45,7 @@ RSpec.describe RfcReader::Command do
       VCR.use_cassette("command-search-for-csv") do
         expect { described_class.start(%w[search csv]) }
           .to output(snapshot("rfc-4180")).to_stdout
-          .and not_to_output.to_stderr
+          .and not_output.to_stderr
       end
 
       catalog = RfcReader::Library.catalog
@@ -66,7 +66,7 @@ RSpec.describe RfcReader::Command do
       VCR.use_cassette("command-search-no-results") do
         expect { described_class.start(%w[search oath2]) }
           .to output("No search results for: oath2\n").to_stderr
-          .and not_to_output.to_stdout
+          .and not_output.to_stdout
       end
 
       expect(RfcReader::Library.catalog).to be_empty
@@ -104,13 +104,13 @@ RSpec.describe RfcReader::Command do
 
       expect { described_class.start(%w[library]) }
         .to output(snapshot("rfc-4180")).to_stdout
-        .and not_to_output.to_stderr
+        .and not_output.to_stderr
     end
 
     it "prints message when library is empty" do
       expect { described_class.start(%w[library]) }
         .to output(empty_library_message).to_stderr
-        .and not_to_output.to_stdout
+        .and not_output.to_stdout
     end
   end
 end

--- a/spec/lib/rfc_reader/error_context_spec.rb
+++ b/spec/lib/rfc_reader/error_context_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RfcReader::ErrorContext do
+  describe ".wrap" do
+    context "with error" do
+      let(:test_error) { StandardError.new("Testing .wrap") }
+
+      it "wraps the error and re-raises it" do
+        error = nil
+
+        begin
+          described_class.wrap("Testing error context wrapper") do
+            raise test_error
+          end
+        rescue described_class::ContextError => e
+          error = e
+        end
+
+        expect(error).to have_attributes(
+          context: "Testing error context wrapper",
+          cause: test_error,
+          message: test_error.message,
+          to_s: test_error.to_s,
+          backtrace: test_error.backtrace,
+          backtrace_locations: test_error.backtrace_locations
+        )
+      end
+    end
+
+    context "without error" do
+      it "returns yielded value", :aggregate_failures do
+        [42, "fourty-two", nil, [4, 2]].each do |value|
+          expect(described_class.wrap("test") { value }).to eq(value)
+        end
+      end
+    end
+  end
+
+  describe ".handler" do
+    context "with error and DEBUG" do
+      before do
+        allow(ENV).to receive(:[]).with("DEBUG").and_return("1")
+      end
+
+      it "handles custom error and returns non-zero exit code", :aggregate_failures do
+        exit_code = nil
+        short_message = <<~MESSAGE
+          Context: ArgumentError: Unexpected date argument...
+          Error: ArgumentError
+          Message:
+             Unexpected date argument...
+          Backtrace:
+        MESSAGE
+
+        expect do
+          exit_code = described_class.handler do
+            raise ArgumentError, "Unexpected date argument..."
+          end
+        end.to output(start_with(short_message)).to_stderr
+          .and not_output.to_stdout
+
+        expect(exit_code).to eq(1)
+      end
+
+      it "handles context error and returns non-zero exit code", :aggregate_failures do
+        exit_code = nil
+        short_message = <<~MESSAGE
+          Context: Parsing date argument
+          Error: ArgumentError
+          Message:
+             Unexpected date argument...
+          Backtrace:
+        MESSAGE
+
+        expect do
+          exit_code = described_class.handler do
+            described_class.wrap("Parsing date argument") do
+              raise ArgumentError, "Unexpected date argument..."
+            end
+          end
+        end.to output(start_with(short_message)).to_stderr
+          .and not_output.to_stdout
+
+        expect(exit_code).to eq(1)
+      end
+    end
+
+    context "with error and without DEBUG" do
+      before do
+        allow(ENV).to receive(:[]).with("DEBUG").and_return(nil)
+      end
+
+      it "handles custom error and returns non-zero exit code", :aggregate_failures do
+        exit_code = nil
+        short_message = <<~MESSAGE
+          Error: ArgumentError: Unexpected date argument...
+          Note: Set the `DEBUG` environment variable to see the full error context
+        MESSAGE
+
+        expect do
+          exit_code = described_class.handler do
+            raise ArgumentError, "Unexpected date argument..."
+          end
+        end.to output(short_message).to_stderr
+          .and not_output.to_stdout
+
+        expect(exit_code).to eq(1)
+      end
+
+      it "handles context error and returns non-zero exit code", :aggregate_failures do
+        exit_code = nil
+        short_message = <<~MESSAGE
+          Error: Parsing date argument
+          Note: Set the `DEBUG` environment variable to see the full error context
+        MESSAGE
+
+        expect do
+          exit_code = described_class.handler do
+            described_class.wrap("Parsing date argument") do
+              raise ArgumentError, "Unexpected date argument..."
+            end
+          end
+        end.to output(short_message).to_stderr
+          .and not_output.to_stdout
+
+        expect(exit_code).to eq(1)
+      end
+    end
+
+    context "without error", :aggregate_failures do
+      it "succeed and returns default exit code" do
+        exit_code = nil
+
+        expect do
+          exit_code = described_class.handler do
+            { one: 1, two: 2 }
+          end
+        end.to not_output.to_stdout
+          .and not_output.to_stderr
+
+        expect(exit_code).to eq(0)
+      end
+
+      it "succeed and returns converted exit code" do
+        exit_code = nil
+
+        expect do
+          exit_code = described_class.handler do
+            nil
+          end
+        end.to not_output.to_stdout
+          .and not_output.to_stderr
+
+        expect(exit_code).to eq(0)
+      end
+
+      it "succeed and returns custom exit code" do
+        exit_code = nil
+
+        expect do
+          exit_code = described_class.handler do
+            5 + 6
+          end
+        end.to not_output.to_stdout
+          .and not_output.to_stderr
+
+        expect(exit_code).to eq(11)
+      end
+    end
+  end
+end

--- a/spec/lib/rfc_reader/error_context_spec.rb
+++ b/spec/lib/rfc_reader/error_context_spec.rb
@@ -47,8 +47,10 @@ RSpec.describe RfcReader::ErrorContext do
       it "handles custom error and returns non-zero exit code", :aggregate_failures do
         exit_code = nil
         short_message = <<~MESSAGE
-          Context: ArgumentError: Unexpected date argument...
-          Error: ArgumentError
+          Context:
+             ArgumentError: Unexpected date argument...
+          Error:
+             ArgumentError
           Message:
              Unexpected date argument...
           Backtrace:
@@ -67,8 +69,10 @@ RSpec.describe RfcReader::ErrorContext do
       it "handles context error and returns non-zero exit code", :aggregate_failures do
         exit_code = nil
         short_message = <<~MESSAGE
-          Context: Parsing date argument
-          Error: ArgumentError
+          Context:
+             Parsing date argument
+          Error:
+             ArgumentError
           Message:
              Unexpected date argument...
           Backtrace:

--- a/spec/lib/rfc_reader/recent_spec.rb
+++ b/spec/lib/rfc_reader/recent_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe RfcReader::Recent do
-  describe "#list" do
+  describe ".list" do
     it "returns the list of recent RFCs" do
       VCR.use_cassette("recent-list") do
         expect(described_class.list).to match_snapshot("recent-list")

--- a/spec/lib/rfc_reader/search_spec.rb
+++ b/spec/lib/rfc_reader/search_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe RfcReader::Search do
-  describe "#search_by" do
+  describe ".search_by" do
     it "returns search for RFCs by term", :aggregate_failures do
       %w[csv http 9600].each do |term|
         VCR.use_cassette("search-by-#{term}") do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,7 +138,7 @@ RSpec.configure do |config|
   end
 end
 
-RSpec::Matchers.define_negated_matcher :not_to_output, :output
+RSpec::Matchers.define_negated_matcher :not_output, :output
 
 VCR.configure do |config|
   config.default_cassette_options = { drop_unused_requests: true }


### PR DESCRIPTION
Closes #5 

The basic idea here is to add error contexts to certain regions of the codebase so that any errors there get labeled appropriately. Additionally, all errors get handled by a new error handler which shows a short message by default, either the context or a default context, or the full error message with context can be displayed by setting the `DEBUG` environment variable.