### PR TITLE
Improve tty prompt settings

### DIFF
--- a/lib/rfc_reader/terminal.rb
+++ b/lib/rfc_reader/terminal.rb
@@ -14,13 +14,12 @@ module RfcReader
       require "tty-prompt"
       TTY::Prompt
         .new(
-          quiet: true,
           track_history: false,
           interrupt: :exit,
           symbols: { marker: ">" },
           enable_color: !ENV["NO_COLOR"]
         )
-        .select(prompt, choices)
+        .select(prompt, choices, per_page: 15)
     end
   end
 end

--- a/spec/fixtures/snapshots/online-search.snap
+++ b/spec/fixtures/snapshots/online-search.snap
@@ -1,6 +1,7 @@
 [?25lChoose an RFC to read: (Press ↑/↓ arrow to move and Enter to select)
 > Common Format and MIME Type for Comma-Separated Values (CSV) Files[2K[1G[1A[2K[1GChoose an RFC to read: 
-> Common Format and MIME Type for Comma-Separated Values (CSV) Files[2K[1G[1A[2K[1G[?25h
+> Common Format and MIME Type for Comma-Separated Values (CSV) Files[2K[1G[1A[2K[1GChoose an RFC to read: Common Format and MIME Type for Comma-Separated Values (CSV) Files
+[?25h
 
 
 


### PR DESCRIPTION
- turns off quiet mode so you can see which rfc you chose after returning from the pager
- increases the per page size from the default of 6 to 15 so that it fills more of the terminal screen and requires less scrolling